### PR TITLE
Add bind mounts for gpio

### DIFF
--- a/cyborg/accelerator/drivers/peripheral/pi_gpio.py
+++ b/cyborg/accelerator/drivers/peripheral/pi_gpio.py
@@ -14,6 +14,7 @@
 import logging
 import os
 from stat import S_ISCHR
+from glob import glob
 
 from cyborg.accelerator.drivers.peripheral.base import BasePeripheralDriver
 
@@ -38,22 +39,34 @@ class PiGPIODriver(BasePeripheralDriver):
             ))
             return []
 
+        gpio_dir = glob("/sys/devices/platform/soc/*fe200000.gpio")
+        if len(gpio_dir) != 1:
+            LOG.error((
+                f"Found {len(gpio_dir)} items for gpio, expected 1"
+            ))
+            return []
+        gpiomem_dir = glob("/sys/devices/platform/soc/*fe200000.gpiomem")
+        if len(gpiomem_dir) != 1:
+            LOG.error((
+                f"Found {len(gpiomem_dir)} items for gpio, expected 1"
+            ))
+            return []
+        bind_mounts = ["/sys/class/gpio", gpio_dir[0], gpiomem_dir[0]]
+
         return [{
             "name": "pi_gpio",
             "vendor": "Raspberry Pi",
             "model": "", # ??
             "traits": ["CUSTOM_GPIO", "CUSTOM_GPIO_RASPBERRY_PI"],
             "oci_runtime": {
+                "mounts": [
+                    {"destination": directory, "source": directory, "options": "bind", "mode": "rw"}
+                    for directory in bind_mounts
+                ],
                 "linux": {
                     "devices": [
                         {"type": "c", "path": GPIO_DEVICE},
                     ],
-                    "capabilities": {
-                        "permitted": ["CAP_SYS_RAWIO"],
-                        "effective": ["CAP_SYS_RAWIO"],
-                        "inherited": ["CAP_SYS_RAWIO"],
-                        "bounding": ["CAP_SYS_RAWIO"],
-                    },
                 },
             }
         }]


### PR DESCRIPTION
It turns out, the posts suggesting to use CAP_SYS_RAWIO are not correct for our case. I've tested this solution on `chiaracer`, and it works to successfully adds a GPIO event using the library we are interested in. It does not work to leave the bind mount's mode as `ro`.

Note that on the Pi3, the gpio directory is in a different place, hence the glob.